### PR TITLE
Final Artifact Collection/Analysis Update

### DIFF
--- a/Code/account/auth-api/artifactRoutes.js
+++ b/Code/account/auth-api/artifactRoutes.js
@@ -152,7 +152,7 @@ router.get('/mine/:userId', async (req, res) => {
                 cultural_affiliation, object_class, bag_number,
                 artifact_id, created_at, updated_at, user_id
          FROM artifacts
-         WHERE user_id = $1 OR user_id IS NULL
+         WHERE user_id = $1
          ORDER BY created_at DESC;
          `;
 

--- a/DIGital/Assets/Localization/Tables/UI Shared Data.asset
+++ b/DIGital/Assets/Localization/Tables/UI Shared Data.asset
@@ -383,6 +383,26 @@ MonoBehaviour:
     m_Key: collection_object_class_input
     m_Metadata:
       m_Items: []
+  - m_Id: 34109210162524160
+    m_Key: analysis_answer_key_button
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34109264260657152
+    m_Key: analysis_user_entry_button
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34109266890485760
+    m_Key: analysis_back_button
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34110989168177152
+    m_Key: analysis_view_mode_text_user_sub
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34111043580882944
+    m_Key: analysis_view_mode_text_answer_key
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/DIGital/Assets/Localization/Tables/UI_en.asset
+++ b/DIGital/Assets/Localization/Tables/UI_en.asset
@@ -410,6 +410,26 @@ MonoBehaviour:
     m_Localized: Enter Object Class...
     m_Metadata:
       m_Items: []
+  - m_Id: 34109210162524160
+    m_Localized: Answer Key
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34109264260657152
+    m_Localized: User Entry
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34109266890485760
+    m_Localized: Back
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34110989168177152
+    m_Localized: User Submission
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34111043580882944
+    m_Localized: Answer Key
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds:

--- a/DIGital/Assets/Localization/Tables/UI_en.asset
+++ b/DIGital/Assets/Localization/Tables/UI_en.asset
@@ -273,7 +273,7 @@ MonoBehaviour:
       m_Items:
       - rid: 745707523204972611
   - m_Id: 757137585106944
-    m_Localized: 'Artifact ID: {id} | {bag} | {date}'
+    m_Localized: 'Artifact ID: {id} | {excavator} | {date}'
     m_Metadata:
       m_Items:
       - rid: 745707523204972611

--- a/DIGital/Assets/Localization/Tables/UI_es.asset
+++ b/DIGital/Assets/Localization/Tables/UI_es.asset
@@ -415,6 +415,26 @@ MonoBehaviour:
     m_Localized: 'Ingrese la clase de objeto:'
     m_Metadata:
       m_Items: []
+  - m_Id: 34109264260657152
+    m_Localized: Entrada de usuario
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34109266890485760
+    m_Localized: "Atr\xE1s"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34109210162524160
+    m_Localized: Clave de respuesta
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34110989168177152
+    m_Localized: Registro del usuario
+    m_Metadata:
+      m_Items: []
+  - m_Id: 34111043580882944
+    m_Localized: Clave de respuestas
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds:

--- a/DIGital/Assets/Localization/Tables/UI_es.asset
+++ b/DIGital/Assets/Localization/Tables/UI_es.asset
@@ -275,7 +275,7 @@ MonoBehaviour:
       m_Items:
       - rid: 745707523204972612
   - m_Id: 757137585106944
-    m_Localized: 'ID del Artefacto: {id} | {bag} | {date}'
+    m_Localized: 'ID del Artefacto: {id} | {excavator} | {date}'
     m_Metadata:
       m_Items:
       - rid: 745707523204972612

--- a/DIGital/Assets/Scenes/ArtifactAnalysis.unity
+++ b/DIGital/Assets/Scenes/ArtifactAnalysis.unity
@@ -2886,8 +2886,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3.7338}
-  m_SizeDelta: {x: 0, y: -7.4673}
+  m_AnchoredPosition: {x: 0.31680298, y: 3.733799}
+  m_SizeDelta: {x: -15.8417, y: -7.4673}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &407815906
 MonoBehaviour:
@@ -5626,8 +5626,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0, y: -6}
+  m_AnchoredPosition: {x: 0.32710266, y: 3.3271008}
+  m_SizeDelta: {x: -12.4292, y: -6.6542}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &793451839
 MonoBehaviour:
@@ -6343,8 +6343,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0.000030518, y: -6}
+  m_AnchoredPosition: {x: 0.32699585, y: 3}
+  m_SizeDelta: {x: -15.0461, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &950475503
 MonoBehaviour:
@@ -6618,8 +6618,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0, y: -6}
+  m_AnchoredPosition: {x: -0, y: 3}
+  m_SizeDelta: {x: -11.0092, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &998776655
 MonoBehaviour:
@@ -6670,8 +6670,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0, y: -6}
+  m_AnchoredPosition: {x: -0.67419434, y: 2.6627998}
+  m_SizeDelta: {x: -12.1379, y: -5.3257}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1001529036
 MonoBehaviour:
@@ -7326,8 +7326,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0.000030518, y: -6}
+  m_AnchoredPosition: {x: -0.32699585, y: 3}
+  m_SizeDelta: {x: -12.4293, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1117718364
 MonoBehaviour:
@@ -8869,7 +8869,7 @@ MonoBehaviour:
     modelObject: {fileID: 292253489}
   - artifactId: 15_626_040
     modelObject: {fileID: 1875435549}
-  - artifactId: 15_132_080
+  - artifactId: 15_312_080
     modelObject: {fileID: 2108694531}
   - artifactId: 25_001_001
     modelObject: {fileID: 311303625}
@@ -8923,8 +8923,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.0013656616, y: 3.0000992}
-  m_SizeDelta: {x: -0.0022583, y: -6.0003}
+  m_AnchoredPosition: {x: -0.0012969971, y: 3.0000992}
+  m_SizeDelta: {x: -9.7881, y: -6.0003}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1368149368
 MonoBehaviour:
@@ -9132,8 +9132,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3.1365}
-  m_SizeDelta: {x: 0.000015259, y: -6.2729}
+  m_AnchoredPosition: {x: 1.2232971, y: 2.8307}
+  m_SizeDelta: {x: -14.679, y: -5.6613}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1398990319
 MonoBehaviour:
@@ -9250,8 +9250,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0, y: -6}
+  m_AnchoredPosition: {x: 0, y: 2.6942005}
+  m_SizeDelta: {x: -13.4557, y: -5.3884}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1411597498
 MonoBehaviour:
@@ -9302,8 +9302,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0, y: -6}
+  m_AnchoredPosition: {x: 0.61169434, y: 3.611599}
+  m_SizeDelta: {x: -12.2323, y: -7.2232}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1429621361
 MonoBehaviour:
@@ -9432,8 +9432,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0.000030518, y: -6}
+  m_AnchoredPosition: {x: -0.63360596, y: 3}
+  m_SizeDelta: {x: -12.6731, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1463267854
 MonoBehaviour:
@@ -9967,8 +9967,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: -0.000030518, y: -6}
+  m_AnchoredPosition: {x: -0.61169434, y: 3.3057995}
+  m_SizeDelta: {x: -12.2326, y: -6.6116}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1502060632
 MonoBehaviour:
@@ -11356,8 +11356,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 4.2004}
-  m_SizeDelta: {x: 0, y: -8.4008}
+  m_AnchoredPosition: {x: 0.3170929, y: 4.5172005}
+  m_SizeDelta: {x: -14.5742, y: -9.0344}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1649037077
 MonoBehaviour:
@@ -13818,8 +13818,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3}
-  m_SizeDelta: {x: 0, y: -6}
+  m_AnchoredPosition: {x: -8.191315, y: 3.3900986}
+  m_SizeDelta: {x: -31.985, y: -6.7801}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1992109859
 MonoBehaviour:

--- a/DIGital/Assets/Scenes/ArtifactAnalysis.unity
+++ b/DIGital/Assets/Scenes/ArtifactAnalysis.unity
@@ -1311,7 +1311,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -968, y: -474}
+  m_AnchoredPosition: {x: -968, y: -513}
   m_SizeDelta: {x: 1394.7, y: 204.352}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &235039201
@@ -1399,7 +1399,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 1.4456787, w: -0.7542572}
+  m_margin: {x: 0, y: 0, z: 1.4456787, w: 56.104958}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -2051,6 +2051,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: -5645937942226959685, guid: f831968292233d64db0e1dac5ff19232, type: 3}
+--- !u!1 &292253489 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -6689036041284674117, guid: f831968292233d64db0e1dac5ff19232, type: 3}
+  m_PrefabInstance: {fileID: 292253488}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &292485163
 GameObject:
   m_ObjectHideFlags: 0
@@ -2291,7 +2296,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 317320426}
   m_TextViewport: {fileID: 1649037076}
   m_TextComponent: {fileID: 2069000748}
@@ -2527,6 +2532,132 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 322913980}
   m_CullTransparentMesh: 1
+--- !u!1 &337390920
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 337390921}
+  - component: {fileID: 337390924}
+  - component: {fileID: 337390923}
+  - component: {fileID: 337390922}
+  m_Layer: 5
+  m_Name: Scrollbar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &337390921
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 337390920}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 376475216}
+  m_Father: {fileID: 1273177178}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 299.37, y: -0.000005722}
+  m_SizeDelta: {x: 19.996, y: 150.28}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &337390922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 337390920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Scrollbar
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.4716981, g: 0.4716981, b: 0.4716981, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1599631073}
+  m_HandleRect: {fileID: 1599631072}
+  m_Direction: 3
+  m_Value: 0
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &337390923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 337390920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &337390924
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 337390920}
+  m_CullTransparentMesh: 1
 --- !u!1 &356893286
 GameObject:
   m_ObjectHideFlags: 0
@@ -2684,6 +2815,42 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 356893286}
   m_CullTransparentMesh: 1
+--- !u!1 &376475215
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 376475216}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &376475216
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 376475215}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1599631072}
+  m_Father: {fileID: 337390921}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &407815904
 GameObject:
   m_ObjectHideFlags: 0
@@ -2719,8 +2886,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.50001526}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3.7338}
+  m_SizeDelta: {x: 0, y: -7.4673}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &407815906
 MonoBehaviour:
@@ -3433,9 +3600,9 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 3
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 2
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 0
@@ -3617,6 +3784,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: -5645937942226959685, guid: 7d639e598be450c47a059ba5c6d1485f, type: 3}
+--- !u!1 &520621211 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -6689036041284674117, guid: 7d639e598be450c47a059ba5c6d1485f, type: 3}
+  m_PrefabInstance: {fileID: 520621210}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &543109177
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4317,7 +4489,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 702045161}
   m_TextViewport: {fileID: 1117718363}
   m_TextComponent: {fileID: 257411604}
@@ -4673,7 +4845,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 741735923}
   m_TextViewport: {fileID: 1463267853}
   m_TextComponent: {fileID: 1498514512}
@@ -4898,6 +5070,142 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 746458505}
+  m_CullTransparentMesh: 1
+--- !u!1 &761029991
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 761029992}
+  - component: {fileID: 761029994}
+  - component: {fileID: 761029993}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &761029992
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 761029991}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1067080559}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &761029993
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 761029991}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Answer Key
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &761029994
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 761029991}
   m_CullTransparentMesh: 1
 --- !u!1 &765044701
 GameObject:
@@ -5318,8 +5626,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.50001526}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &793451839
 MonoBehaviour:
@@ -5536,6 +5844,10 @@ MonoBehaviour:
   StatusText: {fileID: 235039201}
   apiUrl: https://digital-ty59.onrender.com/api/artifacts
   table: UI
+  AnswerKeyButton: {fileID: 1067080558}
+  UserSubmissionButton: {fileID: 1471092855}
+  ContinueButton: {fileID: 1275067264}
+  ViewModeText: {fileID: 1278565893}
   artifactPivot: {fileID: 591620440}
   LoadingList: analysis_status_loading_list
   ErrorLoadingList: analysis_status_error_loading_list
@@ -5549,7 +5861,7 @@ MonoBehaviour:
   DropdownPlaceholderKey: analysis_dropdown_placeholder
   ServerErrorDetails: analysis_status_server_error_details
   modelRegistry: {fileID: 1365976231}
-  defaultModel: {fileID: 0}
+  defaultModel: {fileID: 311303625}
   BackgroundPanel: {fileID: 210723479}
 --- !u!1 &829231486
 GameObject:
@@ -5962,7 +6274,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_TextWrappingMode: 3
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 2
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 0
@@ -6031,8 +6343,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.5}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0.000030518, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &950475503
 MonoBehaviour:
@@ -6048,6 +6360,142 @@ MonoBehaviour:
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.RectMask2D
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &981091560
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 981091561}
+  - component: {fileID: 981091563}
+  - component: {fileID: 981091562}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &981091561
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 981091560}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1471092856}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &981091562
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 981091560}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: User Entry
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &981091563
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 981091560}
+  m_CullTransparentMesh: 1
 --- !u!1 &983701226
 GameObject:
   m_ObjectHideFlags: 0
@@ -6170,8 +6618,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.4999962}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &998776655
 MonoBehaviour:
@@ -6222,8 +6670,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.4999962}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1001529036
 MonoBehaviour:
@@ -6635,6 +7083,139 @@ MonoBehaviour:
   target: {fileID: 1066966072}
   table: UI
   key: artifact_collection_unit
+--- !u!1 &1067080558
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1067080559}
+  - component: {fileID: 1067080562}
+  - component: {fileID: 1067080561}
+  - component: {fileID: 1067080560}
+  m_Layer: 5
+  m_Name: AnswerKeyButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1067080559
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1067080558}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 761029992}
+  m_Father: {fileID: 1340603749}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -959, y: 475.73022}
+  m_SizeDelta: {x: 224.1705, y: 53.46}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1067080560
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1067080558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1067080561}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 825878035}
+        m_TargetAssemblyTypeName: ArtifactAnalysisManager, Assembly-CSharp
+        m_MethodName: OnAnswerKeyButtonClicked
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1067080561
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1067080558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1067080562
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1067080558}
+  m_CullTransparentMesh: 1
 --- !u!1 &1102034046
 GameObject:
   m_ObjectHideFlags: 0
@@ -6745,8 +7326,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.50001526}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0.000030518, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1117718364
 MonoBehaviour:
@@ -7541,6 +8122,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1992109858}
+  - {fileID: 337390921}
   m_Father: {fileID: 1340603749}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -7587,12 +8169,12 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 1273177180}
   m_TextViewport: {fileID: 1992109858}
   m_TextComponent: {fileID: 472601672}
   m_Placeholder: {fileID: 1575739973}
-  m_VerticalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 337390922}
   m_VerticalScrollbarEventHandler: {fileID: 0}
   m_LayoutGroup: {fileID: 0}
   m_ScrollSensitivity: 1
@@ -7600,7 +8182,7 @@ MonoBehaviour:
   m_InputType: 0
   m_AsteriskChar: 42
   m_KeyboardType: 0
-  m_LineType: 0
+  m_LineType: 2
   m_HideMobileInput: 0
   m_HideSoftKeyboard: 0
   m_CharacterValidation: 0
@@ -7687,6 +8269,275 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1273177177}
   m_CullTransparentMesh: 1
+--- !u!1 &1275067264
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1275067265}
+  - component: {fileID: 1275067268}
+  - component: {fileID: 1275067267}
+  - component: {fileID: 1275067266}
+  m_Layer: 5
+  m_Name: BackButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1275067265
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275067264}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1987921471}
+  m_Father: {fileID: 1340603749}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 466, y: 478}
+  m_SizeDelta: {x: 160, y: 53.46}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1275067266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275067264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.35819215, g: 1, b: 0.3254717, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1275067267}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 825878035}
+        m_TargetAssemblyTypeName: ArtifactAnalysisManager, Assembly-CSharp
+        m_MethodName: OnContinueToExcavationButtonClicked
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1275067267
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275067264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1275067268
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275067264}
+  m_CullTransparentMesh: 1
+--- !u!1 &1278565890
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1278565891}
+  - component: {fileID: 1278565892}
+  - component: {fileID: 1278565893}
+  m_Layer: 5
+  m_Name: ViewModeText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1278565891
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1278565890}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1340603749}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -468, y: 478}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1278565892
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1278565890}
+  m_CullTransparentMesh: 1
+--- !u!114 &1278565893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1278565890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: ...
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1340603748
 GameObject:
   m_ObjectHideFlags: 0
@@ -7751,6 +8602,10 @@ RectTransform:
   - {fileID: 1955532160}
   - {fileID: 235039200}
   - {fileID: 1845090925}
+  - {fileID: 1067080559}
+  - {fileID: 1471092856}
+  - {fileID: 1275067265}
+  - {fileID: 1278565891}
   m_Father: {fileID: 1560369476}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -7874,7 +8729,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 1346225354}
   m_TextViewport: {fileID: 950475502}
   m_TextComponent: {fileID: 1775502272}
@@ -8004,20 +8859,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::ArtifactSceneModelRegistry
   entries:
-  - artifactId: 1
+  - artifactId: 15_609_11
+    modelObject: {fileID: 520621211}
+  - artifactId: 10_000_a
+    modelObject: {fileID: 1439756965}
+  - artifactId: 10_197_4
+    modelObject: {fileID: 1399364410}
+  - artifactId: 10_192_4
+    modelObject: {fileID: 292253489}
+  - artifactId: 15_626_040
+    modelObject: {fileID: 1875435549}
+  - artifactId: 15_132_080
+    modelObject: {fileID: 2108694531}
+  - artifactId: 25_001_001
     modelObject: {fileID: 311303625}
-  - artifactId: 2
-    modelObject: {fileID: 0}
-  - artifactId: 3
-    modelObject: {fileID: 0}
-  - artifactId: 4
-    modelObject: {fileID: 0}
-  - artifactId: 5
-    modelObject: {fileID: 0}
-  - artifactId: 6
-    modelObject: {fileID: 0}
-  - artifactId: 7
-    modelObject: {fileID: 0}
 --- !u!4 &1365976232
 Transform:
   m_ObjectHideFlags: 0
@@ -8068,8 +8923,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.4999962}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: -0.0013656616, y: 3.0000992}
+  m_SizeDelta: {x: -0.0022583, y: -6.0003}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1368149368
 MonoBehaviour:
@@ -8277,8 +9132,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.5}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3.1365}
+  m_SizeDelta: {x: 0.000015259, y: -6.2729}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1398990319
 MonoBehaviour:
@@ -8355,6 +9210,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: -5645937942226959685, guid: d0b2afb6cb2b0574280b7a4a665fb824, type: 3}
+--- !u!1 &1399364410 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -6689036041284674117, guid: d0b2afb6cb2b0574280b7a4a665fb824, type: 3}
+  m_PrefabInstance: {fileID: 1399364409}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1411597496
 GameObject:
   m_ObjectHideFlags: 0
@@ -8390,8 +9250,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.4999962}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1411597498
 MonoBehaviour:
@@ -8442,8 +9302,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.4999962}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1429621361
 MonoBehaviour:
@@ -8532,6 +9392,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: -5645937942226959685, guid: 26434cebce26e7244bfc7a534f71d075, type: 3}
+--- !u!1 &1439756965 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -6689036041284674117, guid: 26434cebce26e7244bfc7a534f71d075, type: 3}
+  m_PrefabInstance: {fileID: 1439756964}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1463267852
 GameObject:
   m_ObjectHideFlags: 0
@@ -8567,8 +9432,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.50001526}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0.000030518, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1463267854
 MonoBehaviour:
@@ -8584,6 +9449,139 @@ MonoBehaviour:
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.RectMask2D
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &1471092855
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1471092856}
+  - component: {fileID: 1471092859}
+  - component: {fileID: 1471092858}
+  - component: {fileID: 1471092857}
+  m_Layer: 5
+  m_Name: UserEntryButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1471092856
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1471092855}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 981091561}
+  m_Father: {fileID: 1340603749}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -714, y: 475.73}
+  m_SizeDelta: {x: 224.1705, y: 53.46}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1471092857
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1471092855}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1471092858}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 825878035}
+        m_TargetAssemblyTypeName: ArtifactAnalysisManager, Assembly-CSharp
+        m_MethodName: OnUserSubmissionButtonClicked
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1471092858
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1471092855}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1471092859
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1471092855}
+  m_CullTransparentMesh: 1
 --- !u!1 &1477803493
 GameObject:
   m_ObjectHideFlags: 0
@@ -8969,8 +9967,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.4999962}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: -0.000030518, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1502060632
 MonoBehaviour:
@@ -9064,7 +10062,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 1503923672}
   m_TextViewport: {fileID: 793451838}
   m_TextComponent: {fileID: 287242393}
@@ -10021,6 +11019,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1589244674}
   m_CullTransparentMesh: 1
+--- !u!1 &1599631071
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1599631072}
+  - component: {fileID: 1599631074}
+  - component: {fileID: 1599631073}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1599631072
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599631071}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 376475216}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1599631073
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599631071}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1599631074
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599631071}
+  m_CullTransparentMesh: 1
 --- !u!1 &1616112560
 GameObject:
   m_ObjectHideFlags: 0
@@ -10283,8 +11356,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.50001526}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 4.2004}
+  m_SizeDelta: {x: 0, y: -8.4008}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1649037077
 MonoBehaviour:
@@ -11304,8 +12377,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1165, y: 465}
-  m_SizeDelta: {x: 259.5038, y: 74.921}
+  m_AnchoredPosition: {x: -1204.9253, y: 475.73022}
+  m_SizeDelta: {x: 228.9222, y: 53.46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1845090926
 MonoBehaviour:
@@ -11485,8 +12558,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 14
-  m_fontSizeBase: 14
+  m_fontSize: 36
+  m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -11501,9 +12574,9 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 2
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 0
@@ -11718,6 +12791,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: -5645937942226959685, guid: 8728755c185783c4296ce2d7334020c2, type: 3}
+--- !u!1 &1875435549 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -6689036041284674117, guid: 8728755c185783c4296ce2d7334020c2, type: 3}
+  m_PrefabInstance: {fileID: 1875435548}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1901730282
 GameObject:
   m_ObjectHideFlags: 0
@@ -12494,6 +13572,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1970061854}
   m_CullTransparentMesh: 1
+--- !u!1 &1987921470
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1987921471}
+  - component: {fileID: 1987921473}
+  - component: {fileID: 1987921472}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1987921471
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987921470}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1275067265}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1987921472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987921470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Back
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1987921473
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987921470}
+  m_CullTransparentMesh: 1
 --- !u!1 &1990646940
 GameObject:
   m_ObjectHideFlags: 0
@@ -12604,8 +13818,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.5000076}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1992109859
 MonoBehaviour:
@@ -12987,7 +14201,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 2051122989}
   m_TextViewport: {fileID: 407815905}
   m_TextComponent: {fileID: 1901730284}
@@ -13841,6 +15055,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: -5645937942226959685, guid: d1b1d4b5ca81c5f4fa196fb59d5a7b67, type: 3}
+--- !u!1 &2108694531 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -6689036041284674117, guid: d1b1d4b5ca81c5f4fa196fb59d5a7b67, type: 3}
+  m_PrefabInstance: {fileID: 2108694530}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2109041435
 GameObject:
   m_ObjectHideFlags: 0

--- a/DIGital/Assets/Scenes/ArtifactAnalysis.unity
+++ b/DIGital/Assets/Scenes/ArtifactAnalysis.unity
@@ -5082,6 +5082,7 @@ GameObject:
   - component: {fileID: 761029992}
   - component: {fileID: 761029994}
   - component: {fileID: 761029993}
+  - component: {fileID: 761029995}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -5207,6 +5208,21 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 761029991}
   m_CullTransparentMesh: 1
+--- !u!114 &761029995
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 761029991}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a588735742ede0488343dfd7193a026, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::AutoLocalizeTMP
+  target: {fileID: 0}
+  table: UI
+  key: analysis_answer_key_button
 --- !u!1 &765044701
 GameObject:
   m_ObjectHideFlags: 0
@@ -6371,6 +6387,7 @@ GameObject:
   - component: {fileID: 981091561}
   - component: {fileID: 981091563}
   - component: {fileID: 981091562}
+  - component: {fileID: 981091564}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -6496,6 +6513,21 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 981091560}
   m_CullTransparentMesh: 1
+--- !u!114 &981091564
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 981091560}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a588735742ede0488343dfd7193a026, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::AutoLocalizeTMP
+  target: {fileID: 0}
+  table: UI
+  key: analysis_user_entry_button
 --- !u!1 &983701226
 GameObject:
   m_ObjectHideFlags: 0
@@ -7119,8 +7151,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -959, y: 475.73022}
-  m_SizeDelta: {x: 224.1705, y: 53.46}
+  m_AnchoredPosition: {x: -773.31323, y: 412.6167}
+  m_SizeDelta: {x: 342.7969, y: 53.46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1067080560
 MonoBehaviour:
@@ -8436,8 +8468,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -468, y: 478}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchoredPosition: {x: -429.48914, y: 481.56238}
+  m_SizeDelta: {x: 277.0217, y: 53.46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1278565892
 CanvasRenderer:
@@ -9485,8 +9517,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -714, y: 475.73}
-  m_SizeDelta: {x: 224.1705, y: 53.46}
+  m_AnchoredPosition: {x: -773.31, y: 475.73}
+  m_SizeDelta: {x: 342.8, y: 53.46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1471092857
 MonoBehaviour:
@@ -13583,6 +13615,7 @@ GameObject:
   - component: {fileID: 1987921471}
   - component: {fileID: 1987921473}
   - component: {fileID: 1987921472}
+  - component: {fileID: 1987921474}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -13708,6 +13741,21 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1987921470}
   m_CullTransparentMesh: 1
+--- !u!114 &1987921474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987921470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a588735742ede0488343dfd7193a026, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::AutoLocalizeTMP
+  target: {fileID: 0}
+  table: UI
+  key: analysis_back_button
 --- !u!1 &1990646940
 GameObject:
   m_ObjectHideFlags: 0

--- a/DIGital/Assets/Scenes/Walk&Excavate.unity
+++ b/DIGital/Assets/Scenes/Walk&Excavate.unity
@@ -14709,7 +14709,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -467.33374, y: -414.88513}
+  m_AnchoredPosition: {x: -467.33374, y: -414}
   m_SizeDelta: {x: 899.207, y: 65.9086}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &676747625
@@ -43777,6 +43777,7 @@ MonoBehaviour:
   ArtifactIdDropdown: {fileID: 1018033924}
   StatusText: {fileID: 676747626}
   PanelRoot: {fileID: 894078662}
+  analysisSceneName: ArtifactAnalysis
   apiUrl: https://digital-ty59.onrender.com/api/artifacts
   table: UI
   errorDetailsKey: artifact_collection_status_error_details
@@ -43789,6 +43790,13 @@ MonoBehaviour:
   surveyScriptsToDisable:
   - {fileID: 257842128}
   - {fileID: 1527703918}
+  excavationUIToHideDuringAnalysis:
+  - {fileID: 1949259072}
+  - {fileID: 2137939139}
+  - {fileID: 548421994}
+  - {fileID: 46888173}
+  - {fileID: 1181669091}
+  - {fileID: 468572795}
 --- !u!4 &1967557270
 Transform:
   m_ObjectHideFlags: 0

--- a/DIGital/Assets/Scenes/Walk&Excavate.unity
+++ b/DIGital/Assets/Scenes/Walk&Excavate.unity
@@ -20493,7 +20493,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &894078663
 RectTransform:
   m_ObjectHideFlags: 0
@@ -43790,6 +43790,7 @@ MonoBehaviour:
   surveyScriptsToDisable:
   - {fileID: 257842128}
   - {fileID: 1527703918}
+  - {fileID: 1649285445}
   excavationUIToHideDuringAnalysis:
   - {fileID: 1949259072}
   - {fileID: 2137939139}

--- a/DIGital/Assets/Scripts/ArtifactAnalysisLaunchContext.cs
+++ b/DIGital/Assets/Scripts/ArtifactAnalysisLaunchContext.cs
@@ -1,0 +1,80 @@
+using System;
+
+// different states of the analysis scene
+    // final analysis is after exacvation and backfill
+    // user submission is when the analysis scene opens from a user recording
+    // answer key when shown from the collection form
+public enum ArtifactAnalysisStart
+{
+    FinalAnalysis,
+    UserSubmissionFromExcavation,
+    AnswerKeyFromExcavation
+}
+
+public static class ArtifactAnalysisLaunchContext
+{
+    public static ArtifactAnalysisStart StartMode = ArtifactAnalysisStart.FinalAnalysis;
+    
+    public static ArtifactRecord UserSubmisson;
+    public static string ArtifactId;
+
+    // see where analysis scene was launched
+    // for Continue button visability
+    public static bool LaunchedFromExcavation
+    {
+        get
+        {
+            return StartMode == ArtifactAnalysisStart.UserSubmissionFromExcavation ||
+                   StartMode == ArtifactAnalysisStart.AnswerKeyFromExcavation;
+        }
+    }
+
+    public static void Clear()
+    {
+        StartMode = ArtifactAnalysisStart.FinalAnalysis;
+        UserSubmisson = null;
+        ArtifactId = null;
+    }
+}
+
+// data
+[Serializable]
+public class ArtifactRecord
+{
+    public int id;
+    public string date_discovered;
+    public string investigator;
+    public string area;
+    public string unit;
+    public string layer;
+    public string site;
+    public string associated_features;
+    public string decorative_tech;
+    public string material;
+    public string firing;
+    public string paint;
+    public string cultural_affiliation;
+    public string object_class;
+    public string bag_number;
+    public string artifact_id;
+    public string created_at;
+    public string updated_at;
+    public string user_id;
+}
+
+[Serializable]
+public class SingleArtifactResponse
+{
+    public bool ok;
+    public string message;
+    public ArtifactRecord artifact;
+    public string error;
+}
+
+[Serializable]
+public class ArtifactListResponse
+{
+    public bool ok;
+    public ArtifactRecord[] artifacts;
+    public string error;
+}

--- a/DIGital/Assets/Scripts/ArtifactAnalysisLaunchContext.cs
+++ b/DIGital/Assets/Scripts/ArtifactAnalysisLaunchContext.cs
@@ -15,7 +15,7 @@ public static class ArtifactAnalysisLaunchContext
 {
     public static ArtifactAnalysisStart StartMode = ArtifactAnalysisStart.FinalAnalysis;
     
-    public static ArtifactRecord UserSubmisson;
+    public static ArtifactRecord UserSubmission;
     public static string ArtifactId;
 
     // see where analysis scene was launched
@@ -32,7 +32,7 @@ public static class ArtifactAnalysisLaunchContext
     public static void Clear()
     {
         StartMode = ArtifactAnalysisStart.FinalAnalysis;
-        UserSubmisson = null;
+        UserSubmission = null;
         ArtifactId = null;
     }
 }

--- a/DIGital/Assets/Scripts/ArtifactAnalysisLaunchContext.cs.meta
+++ b/DIGital/Assets/Scripts/ArtifactAnalysisLaunchContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 88aa193d6fb4e9246acb509f60a26af0

--- a/DIGital/Assets/Scripts/ArtifactAnalysisManager.cs
+++ b/DIGital/Assets/Scripts/ArtifactAnalysisManager.cs
@@ -49,6 +49,13 @@ public class ArtifactAnalysisManager : MonoBehaviour
     [Header("Localization")]
     [SerializeField] private string table = "UI";
 
+    // artifact analysis reference buttons
+    [Header("Comparison Buttons")]
+    [SerializeField] private GameObject AnswerKeyButton;
+    [SerializeField] private GameObject UserSubmissionButton;
+    [SerializeField] private GameObject ContinueButton;
+    [SerializeField] private TMP_Text ViewModeText;
+
     // artifact pivot
     [Header("3D Preview Pivot")]
     [SerializeField] private Transform artifactPivot;
@@ -82,44 +89,14 @@ public class ArtifactAnalysisManager : MonoBehaviour
     private LocalizedString lsDropdownLabel;
     private LocalizedString lsDropdownPlaceholder;
 
-    // node app variables
-    [System.Serializable]
-    private class Artifact
-    {
-        public int id;
-        public string date_discovered;
-        public string investigator;
-        public string area;
-        public string unit;
-        public string layer;
-        public string site;
-        public string associated_features;
-        public string decorative_tech;
-        public string material;
-        public string firing;
-        public string paint;
-        public string cultural_affiliation;
-        public string object_class;
-        public string bag_number;
-        public string artifact_id;
-        public string created_at;
-        public string updated_at;
-        public string user_id;
-    }
-
-    [System.Serializable]
-    private class ArtifactListResponse
-    {
-        public bool ok;
-        public Artifact[] artifacts;
-        public string error;
-    }
-
     [Header("UI Panel")]
     [SerializeField] private GameObject BackgroundPanel;
 
     // local cache of artifacts
-    private List<Artifact> _artifacts = new List<Artifact>();
+    private List<ArtifactRecord> _artifacts = new List<ArtifactRecord>();
+    private ArtifactRecord currentUserSubmission;
+    private ArtifactRecord currentAnswerKey;
+    private string currentArtifactId;
 
     public GameObject CurrentActiveModel { get; private set; }
 
@@ -194,10 +171,52 @@ public class ArtifactAnalysisManager : MonoBehaviour
             return;
         } */
 
-        // make input fields read only
+        Debug.Log(
+            $"[ArtifactAnalysisManager] Start() called. " +
+            $"LaunchedFromExcavation={ArtifactAnalysisLaunchContext.LaunchedFromExcavation}, " +
+            $"StartMode={ArtifactAnalysisLaunchContext.StartMode}, " +
+            $"ArtifactId={ArtifactAnalysisLaunchContext.ArtifactId}"
+        );
+
+        // set fields to read only
         SetFieldsReadOnly(true);
 
-        if( StatusText != null )
+        // set bool
+        bool launchedFromExcavation = ArtifactAnalysisLaunchContext.LaunchedFromExcavation;
+
+        if (ContinueButton != null)
+        {
+            ContinueButton.SetActive(launchedFromExcavation);
+        }
+
+        if (launchedFromExcavation)
+        {
+            SetupFromExcavationLaunch();
+            return;
+        }
+
+        // normal/final Analysis scene mode
+        if (SelectArtifact != null)
+        {
+            SelectArtifact.gameObject.SetActive(true);
+        }
+
+        if (AnswerKeyButton != null)
+        {
+            AnswerKeyButton.SetActive(true);
+        }
+
+        if (UserSubmissionButton != null)
+        {
+            UserSubmissionButton.SetActive(false);
+        }
+
+        if (ViewModeText != null)
+        {
+            ViewModeText.text = "";
+        }
+
+        if (StatusText != null)
         {
             SetStatus(LoadingList);
         }
@@ -292,13 +311,23 @@ public class ArtifactAnalysisManager : MonoBehaviour
         }
 
         // select artifact
-        Artifact selectedArtifact = _artifacts[artifactIndex];
-        PopulateUI(selectedArtifact);
+        ArtifactRecord selectedArtifact = _artifacts[artifactIndex];
 
-        // hide background panel TEMP WORKAROUND TO SHOW 3D MODEL
-        if( BackgroundPanel != null )
+        currentUserSubmission = selectedArtifact;
+        currentAnswerKey = null;
+        currentArtifactId = selectedArtifact.artifact_id;
+
+        PopulateUI(selectedArtifact);
+        SetViewMode("User Submission");
+
+        if (UserSubmissionButton != null)
         {
-            BackgroundPanel.SetActive(false);
+            UserSubmissionButton.SetActive(true);
+        }
+
+        if (AnswerKeyButton != null)
+        {
+            AnswerKeyButton.SetActive(true);
         }
 
         if( StatusText != null )
@@ -323,7 +352,7 @@ public class ArtifactAnalysisManager : MonoBehaviour
         {
             if( field == null ) continue;
             field.readOnly = readOnly;
-            field.interactable = !readOnly;
+            field.interactable = true;
         }
 
         if (ArtifactIdDropdown != null)
@@ -352,6 +381,12 @@ public class ArtifactAnalysisManager : MonoBehaviour
     // clear fields when placeholder is selected
     private void ClearUI()
     {
+        // reset comparison
+        currentUserSubmission = null;
+        currentAnswerKey = null;
+        currentArtifactId = null;
+        SetViewMode("");
+
         DateDiscoveredInput.text = "";
         InvestigatorInput.text = "";
         AreaInput.text = "";
@@ -383,6 +418,11 @@ public class ArtifactAnalysisManager : MonoBehaviour
         if (BackgroundPanel != null)
         {
             BackgroundPanel.SetActive(true);
+        }
+
+        if (UserSubmissionButton != null)
+        {
+            UserSubmissionButton.SetActive(false);
         }
     }
 
@@ -451,7 +491,7 @@ public class ArtifactAnalysisManager : MonoBehaviour
             }
 
             // get artifact list
-            _artifacts = new List<Artifact>(response.artifacts);
+            _artifacts = new List<ArtifactRecord>(response.artifacts);
 
             if( _artifacts.Count == 0 )
             {
@@ -509,6 +549,7 @@ public class ArtifactAnalysisManager : MonoBehaviour
             };
 
             string label = lsDropdownLabel.GetLocalizedString();
+            Debug.Log($"[ArtifactAnalysisManager] Dropdown option added: {label}");
             options.Add(new TMP_Dropdown.OptionData(label));
         }
 
@@ -521,8 +562,15 @@ public class ArtifactAnalysisManager : MonoBehaviour
     }
 
     // populate input fields
-    private void PopulateUI(Artifact artifact)
+    private void PopulateUI(ArtifactRecord artifact)
     {
+        if (artifact == null)
+        {
+            ClearUI();
+            SetStatus(NoArtifactData);
+            return;
+        }
+
         // format date
         if (!string.IsNullOrEmpty(artifact.date_discovered))
         {
@@ -548,15 +596,21 @@ public class ArtifactAnalysisManager : MonoBehaviour
         CulturalAffiliationInput.text = artifact.cultural_affiliation;
         ObjectClassInput.text = artifact.object_class;
         BagNumberInput.text = artifact.bag_number;
+
         SetArtifactIdDropdown(artifact.artifact_id);
         ShowModelForArtifact(artifact);
+
+        if (BackgroundPanel != null)
+        {
+            BackgroundPanel.SetActive(false);
+        }
     }
 
-    private void ShowModelForArtifact(Artifact artifact)
+    private void ShowModelForArtifact(ArtifactRecord artifact)
     {
         // turn off all models referenced by the registry (so only one shows)
         if (modelRegistry != null)
-        modelRegistry.HideAll();
+            modelRegistry.HideAll();
 
         // hide default model (optional if we use one later)
         if (defaultModel != null)
@@ -579,6 +633,13 @@ public class ArtifactAnalysisManager : MonoBehaviour
         if (model != null)
         {
             model.SetActive(true);
+
+            Debug.Log(
+                $"[ArtifactAnalysisManager] Activated model '{model.name}' " +
+                $"activeSelf={model.activeSelf}, activeInHierarchy={model.activeInHierarchy}, " +
+                $"parent={(model.transform.parent != null ? model.transform.parent.name : "none")}"
+            );
+
             CurrentActiveModel = model;
             SetupPivotWithoutMovingModel(CurrentActiveModel);
             return;
@@ -586,6 +647,7 @@ public class ArtifactAnalysisManager : MonoBehaviour
 
         // fallback if no match
         Debug.LogWarning($"[ArtifactAnalysisManager] No model found for artifact_id '{id}'. Using default model.");
+        
         if (defaultModel != null)
         {
             defaultModel.SetActive(true);
@@ -618,5 +680,164 @@ public class ArtifactAnalysisManager : MonoBehaviour
 
         // parent the model to the pivot
         model.transform.SetParent(artifactPivot, worldPositionStays: true);
+    }
+
+    // setup analysis scene if launched from excavation
+    private void SetupFromExcavationLaunch()
+    {
+        Debug.Log(
+            $"[ArtifactAnalysisManager] SetupFromExcavationLaunch() called. " +
+            $"ArtifactId={ArtifactAnalysisLaunchContext.ArtifactId}, " +
+            $"HasUserSubmission={ArtifactAnalysisLaunchContext.UserSubmission != null}"
+        );
+
+        currentUserSubmission = ArtifactAnalysisLaunchContext.UserSubmission;
+        currentAnswerKey = null;
+        currentArtifactId = ArtifactAnalysisLaunchContext.ArtifactId;
+
+        if (SelectArtifact != null)
+        {
+            SelectArtifact.gameObject.SetActive(false);
+        }
+
+        bool hasUserSubmission = currentUserSubmission != null;
+
+        if (AnswerKeyButton != null)
+        {
+            AnswerKeyButton.SetActive(hasUserSubmission);
+        }
+
+        if (UserSubmissionButton != null)
+        {
+            UserSubmissionButton.SetActive(hasUserSubmission);
+        }
+
+        if (ArtifactAnalysisLaunchContext.StartMode == ArtifactAnalysisStart.UserSubmissionFromExcavation &&
+            currentUserSubmission != null)
+        {
+            PopulateUI(currentUserSubmission);
+            SetViewMode("User Submission");
+            SetStatus(DataLoaded);
+        }
+
+        else
+        {
+            StartCoroutine(LoadAnswerKeyCoroutine(currentArtifactId));
+        }
+    }
+
+    // answer key button logic to switch from user submission to reference
+    public void OnAnswerKeyButtonClicked()
+    {
+        if (string.IsNullOrWhiteSpace(currentArtifactId))
+        {
+            SetStatus(InvalidSelection);
+            return;
+        }
+
+        if (currentAnswerKey != null)
+        {
+            PopulateUI(currentAnswerKey);
+            SetViewMode("Answer Key");
+            SetStatus(DataLoaded);
+            return;
+        }
+
+        StartCoroutine(LoadAnswerKeyCoroutine(currentArtifactId));
+    }
+
+    // user submission button logic to switch from reference to user submission
+    public void OnUserSubmissionButtonClicked()
+    {
+        if (currentUserSubmission == null)
+        {
+            SetStatus(NoArtifactData);
+            return;
+        }
+
+        PopulateUI(currentUserSubmission);
+        SetViewMode("User Submission");
+        SetStatus(DataLoaded);
+    }
+
+    // continue button to return to excavation scene
+    // ONLY VISIBLE WHEN ANALYSIS IS LAUNCHED FROM EXCAVATION
+    public void OnContinueToExcavationButtonClicked()
+    {
+        ArtifactFormManager formManager = FindFirstObjectByType<ArtifactFormManager>();
+
+        if (formManager != null)
+        {
+            formManager.RestoreAfterAnalysisScene();
+        }
+
+        ArtifactAnalysisLaunchContext.Clear();
+
+        SceneManager.UnloadSceneAsync(gameObject.scene);
+    }
+
+    // coroutine to load answer keys based on user submission artifactId
+    // similar to the coroutine to auto-fill collection form
+    private IEnumerator LoadAnswerKeyCoroutine(string artifactId)
+    {
+        Debug.Log($"[ArtifactAnalysisManager] LoadAnswerKeyCoroutine() started for artifactId='{artifactId}'");
+
+        if (string.IsNullOrWhiteSpace(artifactId))
+        {
+            SetStatus(InvalidSelection);
+            yield break;
+        }
+
+        string url = $"{apiUrl}/reference/{UnityWebRequest.EscapeURL(artifactId)}";
+
+        Debug.Log($"[ArtifactAnalysisManager] Loading answer key from: {url}");
+
+        using (UnityWebRequest request = UnityWebRequest.Get(url))
+        {
+            request.timeout = 10;
+
+            yield return request.SendWebRequest();
+
+            Debug.Log(
+                $"[ArtifactAnalysisManager] Answer key request finished. " +
+                $"Result={request.result}, Code={request.responseCode}, Text={request.downloadHandler.text}"
+            );
+
+            if (request.result != UnityWebRequest.Result.Success)
+            {
+                string serverText = request.downloadHandler != null
+                    ? request.downloadHandler.text
+                    : "";
+
+                Debug.LogError(
+                    $"Error fetching answer key: " +
+                    $"{request.responseCode} - {request.error} - {serverText}");
+
+                SetStatus(ErrorLoadingList);
+                yield break;
+            }
+
+            SingleArtifactResponse response =
+                JsonUtility.FromJson<SingleArtifactResponse>(request.downloadHandler.text);
+
+            if (response == null || !response.ok || response.artifact == null)
+            {
+                SetStatus(NoArtifactData);
+                yield break;
+            }
+
+            currentAnswerKey = response.artifact;
+            PopulateUI(currentAnswerKey);
+            SetViewMode("Answer Key");
+            SetStatus(DataLoaded);
+        }
+    }
+
+    private void SetViewMode(string label)
+    {
+        if (ViewModeText != null)
+        {
+            ViewModeText.text = label;
+        }
     }
 }

--- a/DIGital/Assets/Scripts/ArtifactAnalysisManager.cs
+++ b/DIGital/Assets/Scripts/ArtifactAnalysisManager.cs
@@ -71,6 +71,10 @@ public class ArtifactAnalysisManager : MonoBehaviour
     [SerializeField] private string SelectAndAnalyze = "analysis_status_select_and_analyze";
     [SerializeField] private string DropdownLabelKey = "analysis_dropdown_label";
     [SerializeField] private string DropdownPlaceholderKey = "analysis_dropdown_placeholder";
+    [SerializeField] private string ViewModeUserSubmissionKey = "analysis_view_mode_text_user_sub";
+    [SerializeField] private string ViewModeAnswerKeyKey = "analysis_view_mode_text_answer_key";
+
+    private string _lastViewModeKey = null;
 
     // re-translation
     private enum StatusMode { None, Key, ServerError }
@@ -138,6 +142,9 @@ public class ArtifactAnalysisManager : MonoBehaviour
 
         // refresh the current status message
         RefreshStatusText();
+
+        // refresh view mode text
+        RefreshViewModeText();
     }
 
     private void RefreshStatusText()
@@ -318,7 +325,7 @@ public class ArtifactAnalysisManager : MonoBehaviour
         currentArtifactId = selectedArtifact.artifact_id;
 
         PopulateUI(selectedArtifact);
-        SetViewMode("User Submission");
+        SetViewMode(ViewModeUserSubmissionKey);
 
         if (UserSubmissionButton != null)
         {
@@ -716,7 +723,7 @@ public class ArtifactAnalysisManager : MonoBehaviour
             currentUserSubmission != null)
         {
             PopulateUI(currentUserSubmission);
-            SetViewMode("User Submission");
+            SetViewMode(ViewModeUserSubmissionKey);
             SetStatus(DataLoaded);
         }
 
@@ -738,7 +745,7 @@ public class ArtifactAnalysisManager : MonoBehaviour
         if (currentAnswerKey != null)
         {
             PopulateUI(currentAnswerKey);
-            SetViewMode("Answer Key");
+            SetViewMode(ViewModeAnswerKeyKey);
             SetStatus(DataLoaded);
             return;
         }
@@ -756,7 +763,7 @@ public class ArtifactAnalysisManager : MonoBehaviour
         }
 
         PopulateUI(currentUserSubmission);
-        SetViewMode("User Submission");
+        SetViewMode(ViewModeUserSubmissionKey);
         SetStatus(DataLoaded);
     }
 
@@ -828,16 +835,42 @@ public class ArtifactAnalysisManager : MonoBehaviour
 
             currentAnswerKey = response.artifact;
             PopulateUI(currentAnswerKey);
-            SetViewMode("Answer Key");
+            SetViewMode(ViewModeAnswerKeyKey);
             SetStatus(DataLoaded);
         }
     }
 
-    private void SetViewMode(string label)
+    private void SetViewMode(string key)
     {
-        if (ViewModeText != null)
+        _lastViewModeKey = key;
+
+        if (ViewModeText == null)
         {
-            ViewModeText.text = label;
+            return;
         }
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            ViewModeText.text = "";
+            return;
+        }
+
+        ViewModeText.text = LocalizationSettings.StringDatabase.GetLocalizedString(table, key);
+    }
+
+    private void RefreshViewModeText()
+    {
+        if (ViewModeText == null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_lastViewModeKey))
+        {
+            ViewModeText.text = "";
+            return;
+        }
+
+        ViewModeText.text = LocalizationSettings.StringDatabase.GetLocalizedString(table, _lastViewModeKey);
     }
 }

--- a/DIGital/Assets/Scripts/ArtifactClickManager.cs
+++ b/DIGital/Assets/Scripts/ArtifactClickManager.cs
@@ -23,6 +23,12 @@ public class ArtifactClickManager : MonoBehaviour
 
     private void Update()
     {
+        // block recording in drone POV
+        if (SurveyModeManager.IsSurveyActive)
+        {
+            return;
+        }
+
         // block when intro is open
         if (WalkExcavateIntroController.IsIntroOpen)
         {

--- a/DIGital/Assets/Scripts/ArtifactFormManager.cs
+++ b/DIGital/Assets/Scripts/ArtifactFormManager.cs
@@ -6,6 +6,7 @@ using TMPro;
 using UnityEngine.Localization;
 using UnityEngine.Localization.Settings;
 using System.Collections.Generic;
+using UnityEngine.SceneManagement;
 
 // class
 public class ArtifactFormManager : MonoBehaviour
@@ -33,6 +34,10 @@ public class ArtifactFormManager : MonoBehaviour
     [SerializeField] private TMP_Text StatusText;
     [SerializeField] private GameObject PanelRoot;
 
+    // analysis scene
+    [Header("Analysis Scene")]
+    [SerializeField] private string analysisSceneName = "ArtifactAnalysis";
+
     // api settings
     [Header("API Settings")]
     [SerializeField] private string apiUrl = 
@@ -55,6 +60,12 @@ public class ArtifactFormManager : MonoBehaviour
     [Header("Input Suspension")]
     [SerializeField] private MonoBehaviour[] playerScriptsToDisable;
     [SerializeField] private MonoBehaviour[] surveyScriptsToDisable;
+
+    // excavation UI to hide during analysis
+    [Header("Excavation UI To Hide During Analysis")]
+    [SerializeField] private GameObject[] excavationUIToHideDuringAnalysis;
+    private readonly Dictionary<GameObject, bool> savedExcavationUIStates =
+        new Dictionary<GameObject, bool>();
 
     private readonly Dictionary<MonoBehaviour, bool> savedScriptStates = new Dictionary<MonoBehaviour, bool>();
 
@@ -279,16 +290,21 @@ public class ArtifactFormManager : MonoBehaviour
     {
         Debug.Log("[ArtifactFormManager] Continue confirmed");
 
-        if (currentArtifactInteractable != null)
+        string artifactId = GetSelectedArtifactId();
+
+        if (string.IsNullOrWhiteSpace(artifactId))
         {
-            currentArtifactInteractable.MarkAsRecorded();
-            currentArtifactInteractable = null;
+            SetStatus("artifact_collection_status_invalid_artifact_id");
+            return;
         }
 
-        // clear, reset, and close form
-        ClearForm();
-        ResetStatusUI();
-        CloseForm();
+        // artfiact analysis flow 
+        ArtifactAnalysisLaunchContext.StartMode = ArtifactAnalysisStart.AnswerKeyFromExcavation;
+        ArtifactAnalysisLaunchContext.UserSubmission = null;
+        ArtifactAnalysisLaunchContext.ArtifactId = artifactId;
+
+        FinishArtifactBeforeAnalysisScene();
+        LoadAnalysisSceneAdditive();
     }
 
     // no button in warning
@@ -351,17 +367,23 @@ public class ArtifactFormManager : MonoBehaviour
                         request.downloadHandler.text);
     #endif
 
-                SetStatus("artifact_collection_status_success");
+                SingleArtifactResponse response =
+                    JsonUtility.FromJson<SingleArtifactResponse>(request.downloadHandler.text);
 
-                ClearForm();
-
-                if (currentArtifactInteractable != null)
+                if (response == null || !response.ok || response.artifact == null)
                 {
-                    currentArtifactInteractable.MarkAsRecorded();
-                    currentArtifactInteractable = null;
+                    SetStatusErrorWithDetails("Artifact was submitted, but the response could not be loaded.");
+                    yield break;
                 }
 
-                CloseForm();
+                SetStatus("artifact_collection_status_success");
+
+                ArtifactAnalysisLaunchContext.StartMode = ArtifactAnalysisStart.UserSubmissionFromExcavation;
+                ArtifactAnalysisLaunchContext.UserSubmission = response.artifact;
+                ArtifactAnalysisLaunchContext.ArtifactId = response.artifact.artifact_id;
+
+                FinishArtifactBeforeAnalysisScene();
+                LoadAnalysisSceneAdditive();
             }
 
             else
@@ -372,6 +394,55 @@ public class ArtifactFormManager : MonoBehaviour
                 SetStatusErrorWithDetails(details);
             }
         }
+    }
+
+    private void FinishArtifactBeforeAnalysisScene()
+    {
+        if (currentArtifactInteractable != null)
+        {
+            currentArtifactInteractable.MarkAsRecorded();
+            currentArtifactInteractable = null;
+        }
+
+        ClearForm();
+        ResetStatusUI();
+        HideContinueWarning();
+
+        if (PanelRoot != null)
+        {
+            PanelRoot.SetActive(false);
+        }
+
+        HideExcavationUIForAnalysis();
+
+        // moving into an additive ArtifactAnalysis scene
+        // keep gameplay scripts disabled until Analysis Continue is clicked.
+        Time.timeScale = 1f;
+        Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
+    }
+
+    // load additive analysis scene
+    private void LoadAnalysisSceneAdditive()
+    {
+        Scene existingScene = SceneManager.GetSceneByName(analysisSceneName);
+
+        if (existingScene.IsValid() && existingScene.isLoaded)
+        {
+            Debug.LogWarning($"[ArtifactFormManager] {analysisSceneName} is already loaded.");
+            return;
+        }
+
+        SceneManager.LoadScene(analysisSceneName, LoadSceneMode.Additive);
+    }
+
+    // called by ArtifactAnalysisManager when the temporary Analysis Continue button is clicked.
+    public void RestoreAfterAnalysisScene()
+    {
+        RestoreExcavationUIAfterAnalysis();
+        RestoreScriptsAfterForm();
+        RestoreCursorAfterForm();
+        Time.timeScale = 1f;
     }
 
     // coroutine to fetch and auto-fill the form
@@ -655,5 +726,39 @@ public class ArtifactFormManager : MonoBehaviour
         }
 
         StartCoroutine(LoadReferenceArtifactCoroutine(selectedId));
+    }
+
+    // hide excavation ui
+    private void HideExcavationUIForAnalysis()
+    {
+        savedExcavationUIStates.Clear();
+
+        if (excavationUIToHideDuringAnalysis == null) return;
+
+        foreach (GameObject UIObject in excavationUIToHideDuringAnalysis)
+        {
+            if (UIObject == null) continue;
+
+            if (!savedExcavationUIStates.ContainsKey(UIObject))
+            {
+                savedExcavationUIStates[UIObject] = UIObject.activeSelf;
+            }
+
+            UIObject.SetActive(false);
+        }
+    }
+
+    // restore excavation ui
+    private void RestoreExcavationUIAfterAnalysis()
+    {
+        foreach (var pair in savedExcavationUIStates)
+        {
+            if (pair.Key != null)
+            {
+                pair.Key.SetActive(pair.Value);
+            }
+        }
+
+        savedExcavationUIStates.Clear();
     }
 }

--- a/DIGital/Assets/Scripts/SurveyModeManager.cs
+++ b/DIGital/Assets/Scripts/SurveyModeManager.cs
@@ -30,6 +30,14 @@ public class SurveyModeManager : MonoBehaviour
 
     public bool IsSurveyModeActive { get; private set; }
 
+    public static bool IsSurveyActive
+    {
+        get
+        {
+            return Instance != null && Instance.IsSurveyModeActive;
+        }
+    }
+
     private CursorLockMode previousLockState;
     private bool previousCursorVisible;
 


### PR DESCRIPTION
Updated artifactRoutes.js so the GET method only returns user specific artifacts. No more answer keys.

Created an ArtifactAnalysisLaunchContext.cs script to control the new analysis scene logic. Users can now call the analysis scene right after the artifact collection form has been completed. The UI logic for the analysis scene changes slightly depending on where the analysis scene was called from.

Updated the UI in the artifact collection form and artifact analysis scene.

Blocked excavation and recording logic while in drone mode, so now it is purely visual.

The collection form now calls the analysis scene to show the user entry vs. the answer key right away.

Added new translations for new UI.